### PR TITLE
fix: ignore node_modules by default at any depth

### DIFF
--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import ignore from "ignore";
 import type { Git } from "./git";
 
+const DEFAULT_IGNORE_PATTERNS = ["**/node_modules/**"];
+
 /**
  * Configuration options for file system operations
  */
@@ -48,7 +50,10 @@ export class NodeFileSystem implements FileSystem {
     options: FileSystemOptions,
   ) {
     this.customIgnoreFilter = ignore();
-    this.customIgnoreFilter.add(options.ignorePatterns);
+    this.customIgnoreFilter.add([
+      ...DEFAULT_IGNORE_PATTERNS,
+      ...options.ignorePatterns,
+    ]);
   }
 
   /**


### PR DESCRIPTION
## Problem
osgrep currently indexes node_modules directories if they're not explicitly listed in .gitignore, which:
- Slows down indexing significantly (thousands of dependency files)
- Pollutes search results with package code
- Is especially problematic in monorepo setups common in AI/ML workflows

## Solution
Always ignore `**/node_modules/**` by default, regardless of .gitignore configuration.

The pattern `**/node_modules/**` matches node_modules at any depth, handling:
- `node_modules/` at root
- `packages/app/node_modules/` in monorepos
- Any nested node_modules directories

## Changes
- Modified `NodeFileSystem` constructor in `src/lib/file.ts` to always prepend `**/node_modules/**` to ignore patterns
- Simple 2-line change, no new flags or complexity
- Users can still use `.osgrepignore` for custom ignore patterns

## Testing
Tested locally with monorepo structure to confirm node_modules at multiple levels are ignored.