### PR TITLE
feat: add --reset flag to index command

### DIFF
--- a/src/lib/local-store.ts
+++ b/src/lib/local-store.ts
@@ -737,6 +737,15 @@ export class LocalStore implements Store {
     }
   }
 
+  async deleteStore(storeId: string): Promise<void> {
+    const db = await this.getDb();
+    try {
+      await db.dropTable(storeId);
+    } catch {
+      // Table might not exist, which is fine
+    }
+  }
+
   async getInfo(storeId: string): Promise<StoreInfo> {
     return {
       name: storeId,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -157,6 +157,11 @@ export interface Store {
   deleteFiles(storeId: string, filePaths: string[]): Promise<void>;
 
   /**
+   * Delete an entire store (drop the table)
+   */
+  deleteStore(storeId: string): Promise<void>;
+
+  /**
    * Optional profiling data for implementations that support it
    */
   getProfile?(): unknown;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,6 +185,15 @@ export class MetaStore {
   delete(filePath: string) {
     delete this.data[filePath];
   }
+
+  deleteByPrefix(prefix: string) {
+    const normalizedPrefix = prefix.endsWith("/") ? prefix : prefix + "/";
+    for (const key of Object.keys(this.data)) {
+      if (key.startsWith(normalizedPrefix)) {
+        delete this.data[key];
+      }
+    }
+  }
 }
 
 export function computeBufferHash(buffer: Buffer): string {


### PR DESCRIPTION
Re: Issue #24 

Adds ability to remove and re-index a repository index from scratch. This drops the LanceDB table and clears associated metadata before re-indexing.

```
# Reset and re-index the current directory
osgrep index --reset

# Reset and re-index a specific path
osgrep index --reset --path /path/to/repo

# Reset a specific store
osgrep --store my-store index --reset
```