### PR TITLE
Fix ONNX runtime crashes when indexing large files

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -140,6 +140,15 @@ export const index = new Command("index")
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
       console.error("Failed to index:", message);
+      
+      // Provide helpful guidance for memory-related errors
+      if (message.includes('Memory exceeded') || message.includes('Napi::Error')) {
+        console.error("\nFor large files causing memory issues, consider:");
+        console.error("- Creating a .osgrep-ignore file to exclude large files");
+        console.error("- Breaking up large files into smaller chunks");
+        console.error("- Check your repository for unusually large files");
+      }
+      
       process.exitCode = 1;
       await gracefulExit(1);
     }


### PR DESCRIPTION
## Summary
- Fixes the "libc++abi: terminating due to uncaught exception of type Napi::Error" crash that occurs when indexing large files
- Adds proper ONNX pipeline disposal and resource cleanup to prevent memory leaks
- Implements graceful shutdown handling and process exit cleanup
- Adds memory pressure monitoring with helpful user guidance

## Changes Made
- Added `dispose()` method to `EmbeddingWorker` class to properly clean up ONNX pipelines
- Implemented process exit handlers (SIGINT, SIGTERM, beforeExit) for cleanup
- Enhanced error handling in pipeline loading with better error messages
- Added memory pressure monitoring that distinguishes between large file issues vs concurrent processing issues
- Improved user-facing error messages with actionable guidance for memory issues

## Test Results
- Successfully tested on repositories with large files without crashes
- Dry run and actual indexing both complete without leaving zombie processes
- Memory warnings now provide targeted guidance based on the type of memory pressure detected

## Problem Solved
Previously, osgrep would crash with a C++ runtime error when indexing large files due to improper cleanup of ONNX runtime resources. This fix ensures:
1. Resources are properly disposed when workers shut down
2. Memory pressure is monitored and users get helpful guidance
3. Process exits cleanly without crashes or zombie processes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added memory diagnostics that warn about high memory usage and offer actionable guidance.
  * Added a graceful disposal mechanism to clean up background pipelines on shutdown.

* **Bug Fixes**
  * Improved error messages for memory- and CPU-fallback failures with clearer, user-facing guidance.
  * Implemented process lifecycle handling to ensure resources are cleaned on termination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->