### PR TITLE
formatTextResults respects --score CLI parameter

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -167,6 +167,7 @@ export const search: Command = new CommanderCommand("search")
           isPlain: shouldBePlain,
           compact: options.compact,
           content: options.content,
+          scores: options.scores,
         });
         console.log(output);
         return true;
@@ -319,6 +320,7 @@ export const search: Command = new CommanderCommand("search")
         isPlain: shouldBePlain,
         compact: options.compact,
         content: options.content,
+        scores: options.scores,
       });
 
       console.log(output);

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -94,6 +94,7 @@ export function formatTextResults(
     isPlain: boolean;
     compact?: boolean;
     content?: boolean;
+    scores?: boolean;
   },
 ): string {
   if (results.length === 0) return `osgrep: No results found for "${query}".`;
@@ -133,6 +134,8 @@ export function formatTextResults(
       if (relPath.includes("test") || relPath.includes("spec")) tags.push("Test");
       const tagStr = tags.length > 0 ? ` [${tags.join(",")}]` : "";
 
+      const scoreStr = options.scores ? ` (score: ${item.score.toFixed(3)})` : "";
+
       const lines = cleanSnippetLines(item.content);
       const truncated =
         !options.content && lines.length > maxLines
@@ -142,7 +145,7 @@ export function formatTextResults(
           ]
           : lines;
 
-      output += `${relPath}:${line}${tagStr}\n`;
+      output += `${relPath}:${line}${tagStr}${scoreStr}\n`;
       truncated.forEach((ln) => {
         output += `  ${ln}\n`;
       });
@@ -209,7 +212,8 @@ export function formatTextResults(
         // fall back to non-highlighted text
       }
 
-      output += `${rank}) 📂 ${style.green(relPath)}${style.dim(`:${line}`)}${tagStr}\n`;
+      const scoreStr = options.scores ? ` ${style.dim(`(score: ${item.score.toFixed(3)})`)}` : "";
+      output += `${rank}) 📂 ${style.green(relPath)}${style.dim(`:${line}`)}${tagStr}${scoreStr}\n`;
       const numbered = rendered.split("\n").map((ln, idx) => {
         const num = style.dim(`${line + idx}`.padStart(4));
         return `${num} │ ${ln}`;


### PR DESCRIPTION
The `osgrep search --scores` option is still present in the CLI, but the chunk formatter ignores it. This PR adds back the scores printing functionality to formatTextResults.

If this change in behavior was intentional, please close this PR (and consider removing the `--scores` parameter).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now support displaying relevance scores alongside each result, helping users identify the most relevant matches in their search output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->