### PR TITLE
Match a broader set of test paths to down-boost

### DIFF
--- a/src/lib/local-store.ts
+++ b/src/lib/local-store.ts
@@ -537,9 +537,8 @@ export class LocalStore implements Store {
     const pathStr =
       typeof record.path === "string" ? record.path.toLowerCase() : "";
     if (
-      pathStr.includes(".test.") ||
-      pathStr.includes(".spec.") ||
-      pathStr.includes("__tests__")
+      pathStr.includes("test") ||
+      pathStr.includes("spec")
     ) {
       adjusted *= 0.85;
     }


### PR DESCRIPTION
The original pathStr.includes checks were letting too many test files through. I worry that this might be too big a change in the opposite direction, though, so maybe these "down-boost" paths should be user-configurable in the future?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded file scoring adjustments to apply to a broader set of file categories, which may impact search ranking and result ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->