### PR TITLE
Add Swift grammar support and skeleton coverage

### DIFF
--- a/src/lib/core/languages.ts
+++ b/src/lib/core/languages.ts
@@ -176,6 +176,25 @@ export const LANGUAGES: LanguageDefinition[] = [
     ],
   },
   {
+    id: "swift",
+    extensions: [".swift"],
+    grammar: {
+      name: "swift",
+      url: "https://github.com/alex-pinkus/tree-sitter-swift/releases/download/0.7.1/tree-sitter-swift.wasm",
+    },
+    definitionTypes: [
+      "function_declaration",
+      "class_declaration",
+      "protocol_declaration",
+      "property_declaration",
+      "typealias_declaration",
+      "init_declaration",
+      "deinit_declaration",
+      "macro_declaration",
+      "subscript_declaration",
+    ],
+  },
+  {
     id: "json",
     extensions: [".json"],
     grammar: {

--- a/src/lib/skeleton/body-fields.ts
+++ b/src/lib/skeleton/body-fields.ts
@@ -109,6 +109,15 @@ export const BODY_FIELDS: Record<string, Record<string, string | null>> = {
     interface_declaration: null,
     trait_declaration: null, // Container
   },
+
+  swift: {
+    function_declaration: "body",
+    init_declaration: "body",
+    deinit_declaration: "body",
+    class_declaration: null, // Container (covers class/struct/enum/actor)
+    protocol_declaration: null, // Container
+    enum_class_body: null, // Container for nested declarations
+  },
 };
 
 /**
@@ -128,6 +137,7 @@ export const CONTAINER_TYPES: Record<string, string[]> = {
   c: [],
   ruby: ["class", "module"],
   php: ["class_declaration", "trait_declaration"],
+  swift: ["class_declaration", "class_body", "enum_class_body", "protocol_declaration", "protocol_body"],
 };
 
 /**


### PR DESCRIPTION
The readme file mentions support for Swift, but there's no Tree-sitter grammar defined in the source code itself. This PR introduces https://github.com/alex-pinkus/tree-sitter-swift grammar for parsing Swift code files, as the official https://github.com/tree-sitter/tree-sitter-swift/ is abandoned

The additional code in `skeletonizer.js` solves the argument names being the part of the Swift function signature. In case we have something like 
```swift
class Greeter {
  func greet(name: String) {} 
  func greet(person: Person) {}
}

func doThing() {
  // ... 
  greeter.greet(name: "Alice")
}
```
only outputting `-> greet` as callee is not enough, there are two separate functions, `greet(name:)` and `greet(person:)` which we need to distinguish

> Implementation is aided by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swift language support, enabling code analysis and navigation for `.swift` files
  * Improved symbol extraction with language-aware processing for more accurate function and declaration identification
  * Enhanced support for Swift-specific constructs including classes, protocols, and initializers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->