### PR TITLE
fix: reject unknown options instead of misparsing as args

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -390,8 +390,6 @@ export const search: Command = new CommanderCommand("search")
   )
   .argument("<pattern>", "The pattern to search for")
   .argument("[path]", "The path to search in")
-  .allowUnknownOption(true)
-  .allowExcessArguments(true)
   .action(async (pattern, exec_path, _options, cmd) => {
     const options: {
       m: string;
@@ -405,10 +403,6 @@ export const search: Command = new CommanderCommand("search")
       dryRun: boolean;
       skeleton: boolean;
     } = cmd.optsWithGlobals();
-
-    if (exec_path?.startsWith("--")) {
-      exec_path = "";
-    }
 
     const root = process.cwd();
     const minScore = Number.isFinite(Number.parseFloat(options.minScore))

--- a/tests/search-command.test.ts
+++ b/tests/search-command.test.ts
@@ -246,4 +246,24 @@ describe("unknown option handling", () => {
       })
     ).rejects.toThrow(/unknown option/i);
   });
+
+  it("rejects unknown options with equals sign", async () => {
+    await expect(
+      (search as Command).parseAsync(["--json=true", "query", "."], {
+        from: "user",
+      })
+    ).rejects.toThrow(/unknown option/i);
+  });
+
+  it("rejects short unknown options", async () => {
+    await expect(
+      (search as Command).parseAsync(["-j", "query", "."], { from: "user" })
+    ).rejects.toThrow(/unknown option/i);
+  });
+
+  it("rejects unknown option that looks like a path", async () => {
+    await expect(
+      (search as Command).parseAsync(["--./path", "query"], { from: "user" })
+    ).rejects.toThrow(/unknown option/i);
+  });
 });

--- a/tests/search-command.test.ts
+++ b/tests/search-command.test.ts
@@ -230,4 +230,20 @@ describe("unknown option handling", () => {
       })
     ).rejects.toThrow(/too many arguments/i);
   });
+
+  it("rejects multiple unknown options", async () => {
+    await expect(
+      (search as Command).parseAsync(["--json", "--xml", "query", "."], {
+        from: "user",
+      })
+    ).rejects.toThrow(/unknown option/i);
+  });
+
+  it("rejects unknown options mixed with valid options", async () => {
+    await expect(
+      (search as Command).parseAsync(["query", "--no-rerank", "--json", "."], {
+        from: "user",
+      })
+    ).rejects.toThrow(/unknown option/i);
+  });
 });

--- a/tests/search-command.test.ts
+++ b/tests/search-command.test.ts
@@ -201,3 +201,33 @@ describe("min-score filtering", () => {
     consoleSpy.mockRestore();
   });
 });
+
+describe("unknown option handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spinner.text = "";
+    (search as Command).exitOverride();
+  });
+
+  it("rejects unknown options instead of misparsing them as arguments", async () => {
+    // Before fix: --json was treated as pattern, "query" as path
+    // After fix: Commander properly rejects unknown options
+    await expect(
+      (search as Command).parseAsync(["--json", "query", "."], { from: "user" })
+    ).rejects.toThrow(/unknown option/i);
+  });
+
+  it("rejects unknown options even when placed after arguments", async () => {
+    await expect(
+      (search as Command).parseAsync(["query", ".", "--json"], { from: "user" })
+    ).rejects.toThrow(/unknown option/i);
+  });
+
+  it("rejects excess arguments", async () => {
+    await expect(
+      (search as Command).parseAsync(["query", ".", "extra", "args"], {
+        from: "user",
+      })
+    ).rejects.toThrow(/too many arguments/i);
+  });
+});

--- a/tests/search-command.test.ts
+++ b/tests/search-command.test.ts
@@ -266,4 +266,22 @@ describe("unknown option handling", () => {
       (search as Command).parseAsync(["--./path", "query"], { from: "user" })
     ).rejects.toThrow(/unknown option/i);
   });
+
+  it("accepts valid options without error", async () => {
+    // Regression: ensure known options still work
+    await expect(
+      (search as Command).parseAsync(["query", ".", "-m", "5", "--compact"], {
+        from: "user",
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it("allows pattern starting with dash using -- separator", async () => {
+    // Standard CLI convention: -- ends option parsing
+    await expect(
+      (search as Command).parseAsync(["--", "-pattern-with-dash", "."], {
+        from: "user",
+      })
+    ).resolves.not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes two interrelated bugs in the `search` command:

1. **Argument Misparsing**: `allowUnknownOption(true)` + `allowExcessArguments(true)` caused unknown flags like `--json` to be treated as positional arguments
2. **Directory Creation**: Misparsed path led to junk directory creation via `ensureProjectPaths()`

### Before
```bash
osgrep search --json "query" .
# "--json" → pattern, "query" → path
# Creates query/.osgrep/ directory, returns 0 results
```

### After
```bash
osgrep search --json "query" .
# error: unknown option '--json'
```

## Changes

- Remove `.allowUnknownOption(true)` and `.allowExcessArguments(true)` from search command
- Remove now-unnecessary `exec_path?.startsWith("--")` workaround
- Add tests confirming unknown options and excess args are rejected

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [x] New tests for unknown option rejection pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search command now strictly validates input: unknown options, excess arguments, and arguments beginning with "--" are rejected instead of being silently accepted or normalized.

* **Tests**
  * Added coverage for unknown-option and excess-argument handling to ensure consistent CLI validation and error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->