### PR TITLE
fix: only cancel /search on real client aborts

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -166,6 +166,11 @@ export const serve = new Command("serve")
                 // Add AbortController for cancellation
                 const ac = new AbortController();
                 req.on("close", () => {
+                  if (req.complete) return;
+                  ac.abort();
+                });
+                res.on("close", () => {
+                  if (res.writableFinished) return;
                   ac.abort();
                 });
 


### PR DESCRIPTION
Fixes https://github.com/Ryandonofrio3/osgrep/issues/79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request cancellation guards to ensure responses complete properly and to avoid unnecessary aborts after a request or response has finished.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->