### PR TITLE
Make GLOBAL_ROOT configurable with env vars

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,8 +46,17 @@ export const MAX_WORKER_MEMORY_MB = Number.parseInt(
   10,
 );
 
-const HOME = os.homedir();
-const GLOBAL_ROOT = path.join(HOME, ".osgrep");
+function getOsgrepHome(): string {
+  if (process.env.OSGREP_HOME) {
+    return path.resolve(process.env.OSGREP_HOME);
+  }
+  // XDG compliance: $XDG_CACHE_HOME/osgrep or ~/.cache/osgrep
+  const xdgCache =
+    process.env.XDG_CACHE_HOME || path.join(os.homedir(), ".cache");
+  return path.join(xdgCache, "osgrep");
+}
+
+const GLOBAL_ROOT = getOsgrepHome();
 
 export const PATHS = {
   globalRoot: GLOBAL_ROOT,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { setup } from "./commands/setup";
 import { skeleton } from "./commands/skeleton";
 import { symbols } from "./commands/symbols";
 import { trace } from "./commands/trace";
+import { PATHS } from "./config";
 
 program
   .version(
@@ -31,14 +32,12 @@ program
     process.env.OSGREP_STORE || undefined,
   );
 
-const legacyDataPath = path.join(
-  require("node:os").homedir(),
-  ".osgrep",
-  "data",
-);
+const legacyDataPath = path.join(PATHS.globalRoot, "data");
 const isIndexCommand = process.argv.some((arg) => arg === "index");
 if (isIndexCommand && fs.existsSync(legacyDataPath)) {
-  console.log("⚠️  Legacy global database detected at ~/.osgrep/data.");
+  console.log(
+    `⚠️  Legacy global database detected at ${PATHS.globalRoot}/data.`,
+  );
   console.log("   osgrep now uses per-project .osgrep/ directories.");
   console.log(
     "   Run 'osgrep index' in your project root to create a new index.",

--- a/src/lib/index/grammar-loader.ts
+++ b/src/lib/index/grammar-loader.ts
@@ -1,10 +1,9 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
-
+import { PATHS } from "../../config";
 import { LANGUAGES } from "../core/languages";
 
-export const GRAMMARS_DIR = path.join(os.homedir(), ".osgrep", "grammars");
+export const GRAMMARS_DIR = PATHS.grammars;
 
 const GRAMMAR_URLS: Record<string, string> = {};
 for (const lang of LANGUAGES) {

--- a/src/lib/setup/model-loader.ts
+++ b/src/lib/setup/model-loader.ts
@@ -1,11 +1,8 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { Worker } from "node:worker_threads";
-import { MODEL_IDS } from "../../config";
+import { MODEL_IDS, PATHS } from "../../config";
 
-const HOMEDIR = os.homedir();
-const CACHE_DIR = path.join(HOMEDIR, ".osgrep", "models");
 const LOG_MODELS =
   process.env.OSGREP_DEBUG_MODELS === "1" ||
   process.env.OSGREP_DEBUG_MODELS === "true";
@@ -61,8 +58,8 @@ export async function downloadModels(): Promise<void> {
  */
 export function areModelsDownloaded(): boolean {
   // Check if the model directories exist in the cache
-  const embedPath = path.join(CACHE_DIR, ...MODEL_IDS.embed.split("/"));
-  const colbertPath = path.join(CACHE_DIR, ...MODEL_IDS.colbert.split("/"));
+  const embedPath = path.join(PATHS.models, ...MODEL_IDS.embed.split("/"));
+  const colbertPath = path.join(PATHS.models, ...MODEL_IDS.colbert.split("/"));
 
   return fs.existsSync(embedPath) && fs.existsSync(colbertPath);
 }

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -1,14 +1,11 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { parentPort } from "node:worker_threads";
 import { env, pipeline } from "@huggingface/transformers";
-import { MODEL_IDS } from "../../config";
+import { MODEL_IDS, PATHS } from "../../config";
 
 // Configuration
-const HOMEDIR = os.homedir();
-const CACHE_DIR = path.join(HOMEDIR, ".osgrep", "models");
-env.cacheDir = CACHE_DIR;
+env.cacheDir = PATHS.models;
 env.allowLocalModels = true;
 env.allowRemoteModels = true;
 
@@ -67,8 +64,8 @@ async function downloadModelWithTimeout(modelId: string, dtype: PipelineDType) {
 // Helper to manually download extra files like skiplist.json
 async function downloadExtraFile(modelId: string, filename: string) {
   const url = `https://huggingface.co/${modelId}/resolve/main/${filename}`;
-  // Construct path: ~/.osgrep/models/ryandono/osgrep-colbert-q8/skiplist.json
-  const destDir = path.join(CACHE_DIR, ...modelId.split("/"));
+  // Construct path: $OSGREP_HOME/models/ryandono/osgrep-colbert-q8/skiplist.json
+  const destDir = path.join(PATHS.models, ...modelId.split("/"));
   const destPath = path.join(destDir, filename);
 
   if (!fs.existsSync(destDir)) {


### PR DESCRIPTION
Currently osgrep uses the directory `~/.osgrep` for its cache. I don't like it when programs use my home dir directly for their cache. 
Therefore this PR adds the OSGREP_HOME environment variable to override the global osgrep directory location
This default to the XDG compliant path ($XDG_CACHE_HOME/osgrep or ~/.cache/osgrep) instead of ~/.osgrep

The path selection priority order is
1. $OSGREP_HOME (if set)
2. $XDG_CACHE_HOME/osgrep (if XDG var set)
3. ~/.cache/osgrep (default)

For testing I ran
```sh
OSGREP_HOME=/tmp/osgrep-test npx osgrep setup
ls /tmp/osgrep-test/  # models/, grammars/
# XDG fallback
XDG_CACHE_HOME=/tmp/xdg npx osgrep setup
ls /tmp/xdg/osgrep/
```

Note: Project-local .osgrep/ directories (for per-repo index data) remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how the application determines storage paths for data, grammars, and models. Now respects OSGREP_HOME environment variable, with fallback to XDG_CACHE_HOME or ~/.cache directory for configuration storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->