### PR TITLE
feat: add --no-rerank flag to serve and search commands

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -388,6 +388,10 @@ export const search: Command = new CommanderCommand("search")
     "Show code skeleton for matching files instead of snippets",
     false,
   )
+  .option(
+    "--no-rerank",
+    "Disable neural reranking for faster results (uses fusion scoring instead)",
+  )
   .argument("<pattern>", "The pattern to search for")
   .argument("[path]", "The path to search in")
   .action(async (pattern, exec_path, _options, cmd) => {
@@ -402,6 +406,7 @@ export const search: Command = new CommanderCommand("search")
       sync: boolean;
       dryRun: boolean;
       skeleton: boolean;
+      rerank: boolean;
     } = cmd.optsWithGlobals();
 
     const root = process.cwd();
@@ -427,6 +432,7 @@ export const search: Command = new CommanderCommand("search")
             path: exec_path
               ? path.relative(projectRootForServer, path.resolve(exec_path))
               : undefined,
+            rerank: options.rerank,
           }),
         });
 
@@ -597,7 +603,7 @@ export const search: Command = new CommanderCommand("search")
       const searchResult = await searcher.search(
         pattern,
         parseInt(options.m, 10),
-        { rerank: true },
+        { rerank: options.rerank },
         undefined,
         exec_path ? path.relative(projectRoot, path.resolve(exec_path)) : "",
       );

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -28,8 +28,9 @@ export const serve = new Command("serve")
     process.env.OSGREP_PORT || "4444",
   )
   .option("-b, --background", "Run in background", false)
+  .option("--no-rerank", "Disable neural reranking for faster responses (uses fusion scoring instead)")
   .action(async (_args, cmd) => {
-    const options: { port: string; background: boolean } =
+    const options: { port: string; background: boolean; rerank: boolean } =
       cmd.optsWithGlobals();
     let port = parseInt(options.port, 10);
     const startPort = port;
@@ -174,10 +175,13 @@ export const serve = new Command("serve")
                   ac.abort();
                 });
 
+                // Respect rerank from request body, falling back to CLI default
+                const rerank = typeof body.rerank === "boolean" ? body.rerank : options.rerank;
+
                 const result = await searcher.search(
                   query,
                   limit,
-                  { rerank: true },
+                  { rerank },
                   undefined,
                   searchPath,
                   undefined, // intent


### PR DESCRIPTION
## Summary

- Add `--no-rerank` flag to `osgrep serve` and `osgrep search`
- The serve `/search` endpoint now respects a `rerank` field in the request body, with the CLI flag as the default

## Problem

The `serve` command hardcodes `{ rerank: true }` when calling `searcher.search()`. On the first search query, this triggers loading of the ~2GB ColBERT neural reranking ONNX model, which takes **>2 minutes** before the first response is returned. This makes `osgrep serve` impractical for interactive use cases (e.g., Neovim pickers, editor integrations) where sub-second latency is expected.

## Solution

Both `serve` and `search` commands now accept `--no-rerank` which passes `{ rerank: false }` to `searcher.search()`. The searcher already handles this case gracefully (line 258 of `searcher.ts`: `const doRerank = _search_options?.rerank ?? true`) by falling back to fusion scoring.

For `serve`, the `/search` endpoint also reads `rerank` from the JSON request body, allowing per-request control. The CLI flag sets the server-wide default.

## Performance

Benchmarked on a small project (~35 files):

| Mode | First query | Warm queries |
|---|---|---|
| `serve` (default, rerank=true) | >120s | ~60ms |
| `serve --no-rerank` | **321ms** | **66ms** |
| `search --no-rerank` (CLI) | ~1.0s | ~1.0s |

The quality difference is minimal — fusion scoring (BM25 + vector similarity) produces good results; neural reranking adds marginal improvement primarily for ambiguous queries.

## Usage

```bash
osgrep serve --no-rerank          # fast server startup, no reranking model loaded
osgrep search "auth" --no-rerank  # fast CLI search without reranking

# Per-request control via the HTTP API:
curl -X POST http://localhost:4444/search \
  -H 'Content-Type: application/json' \
  -d '{"query": "authentication", "limit": 10, "rerank": false}'
```

## Changes

- `src/commands/serve.ts`: Add `--no-rerank` option, read `rerank` from request body with CLI default fallback
- `src/commands/search.ts`: Add `--no-rerank` option, pass to `searcher.search()`, forward to server when using HTTP client path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-rerank` CLI option to disable neural reranking
  * Reranking behavior is now configurable for both search and serve commands
  * HTTP server endpoints support per-request reranking overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->